### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ class Car
     private $id;
     
     /**
-     * @Field(type="VARCAR")
+     * @Field(type="VARCHAR")
      */
     private $name;
     


### PR DESCRIPTION
`VARCAR` > `VARCHAR`
This is probably not a car.