### PR TITLE
SQL injection fix: Coerce offset and limit values to integers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 vendor/
 composer.phar
+composer.lock
 autoload.php
 phpunit.xml
 php-cs-fixer.phar

--- a/src/Propel/Runtime/ActiveQuery/Criteria.php
+++ b/src/Propel/Runtime/ActiveQuery/Criteria.php
@@ -1263,8 +1263,7 @@ class Criteria
     /**
      * Set offset.
      *
-     * @param  int            $offset An int with the value for offset.  (Note this values is
-     *                        cast to a 32bit integer and may result in truncation)
+     * @param  int            $offset An int with the value for offset.
      * @return $this|Criteria Modified Criteria object (for fluent API)
      */
     public function setOffset($offset)

--- a/src/Propel/Runtime/ActiveQuery/Criteria.php
+++ b/src/Propel/Runtime/ActiveQuery/Criteria.php
@@ -1245,8 +1245,7 @@ class Criteria
      */
     public function setLimit($limit)
     {
-        // TODO: do we enforce int here? 32bit issue if we do
-        $this->limit = $limit;
+        $this->limit = (int) $limit;
 
         return $this;
     }

--- a/src/Propel/Runtime/Adapter/Pdo/MysqlAdapter.php
+++ b/src/Propel/Runtime/Adapter/Pdo/MysqlAdapter.php
@@ -120,6 +120,9 @@ class MysqlAdapter extends PdoAdapter
      */
     public function applyLimit(&$sql, $offset, $limit)
     {
+        $offset = (int) $offset;
+        $limit = (int) $limit;
+
         if ($limit >= 0) {
             $sql .= ' LIMIT ' . ($offset > 0 ? $offset . ', ' : '') . $limit;
         } elseif ($offset > 0) {

--- a/tests/Propel/Tests/Runtime/ActiveQuery/CriteriaTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/CriteriaTest.php
@@ -1021,14 +1021,158 @@ class CriteriaTest extends BookstoreTestBase
         $this->assertFalse($c->getUseTransaction(), 'useTransaction is false by default');
     }
 
-    public function testLimit()
+    public function testDefaultLimit()
     {
         $c = new Criteria();
         $this->assertEquals(-1, $c->getLimit(), 'Limit is -1 by default');
+    }
 
-        $c2 = $c->setLimit(1);
-        $this->assertEquals(1, $c->getLimit(), 'Limit is set by setLimit');
+    /**
+     * @dataProvider dataLimit
+     */
+    public function testLimit($limit, $expected)
+    {
+        $c = new Criteria();
+        $c2 = $c->setLimit($limit);
+
+        $this->assertSame($expected, $c->getLimit(), 'Correct limit is set by setLimit()');
         $this->assertSame($c, $c2, 'setLimit() returns the current Criteria');
+    }
+
+    public function dataLimit()
+    {
+        return array(
+            'Negative value' => array(
+                'limit'    => -1,
+                'expected' => -1
+            ),
+            'Zero' => array(
+                'limit'    => 0,
+                'expected' => 0
+            ),
+
+            'Small integer' => array(
+                'limit'    => 38427,
+                'expected' => 38427
+            ),
+            'Small integer as a string' => array(
+                'limit'    => '38427',
+                'expected' => 38427
+            ),
+
+            'Largest 32-bit integer' => array(
+                'limit'    => 2147483647,
+                'expected' => 2147483647
+            ),
+            'Largest 32-bit integer as a string' => array(
+                'limit'    => '2147483647',
+                'expected' => 2147483647
+            ),
+
+            'Largest 64-bit integer' => array(
+                'limit'    => 9223372036854775807,
+                'expected' => 9223372036854775807
+            ),
+            'Largest 64-bit integer as a string' => array(
+                'limit'    => '9223372036854775807',
+                'expected' => 9223372036854775807
+            ),
+
+            'Decimal value' => array(
+                'limit'    => 123.9,
+                'expected' => 123
+            ),
+            'Decimal value as a string' => array(
+                'limit'    => '123.9',
+                'expected' => 123
+            ),
+
+            'Non-numeric string' => array(
+                'limit'    => 'foo',
+                'expected' => 0
+            ),
+            'Injected SQL' => array(
+                'limit'    => '3;DROP TABLE abc',
+                'expected' => 3
+            ),
+        );
+    }
+
+    public function testDefaultOffset()
+    {
+        $c = new Criteria();
+        $this->assertEquals(0, $c->getOffset(), 'Offset is 0 by default');
+    }
+
+    /**
+     * @dataProvider dataOffset
+     */
+    public function testOffset($offset, $expected)
+    {
+        $c = new Criteria();
+        $c2 = $c->setOffset($offset);
+
+        $this->assertSame($expected, $c->getOffset(), 'Correct offset is set by setOffset()');
+        $this->assertSame($c, $c2, 'setOffset() returns the current Criteria');
+    }
+
+    public function dataOffset()
+    {
+        return array(
+            'Negative value' => array(
+                'offset'   => -1,
+                'expected' => -1
+            ),
+            'Zero' => array(
+                'offset'   => 0,
+                'expected' => 0
+            ),
+
+            'Small integer' => array(
+                'offset'   => 38427,
+                'expected' => 38427
+            ),
+            'Small integer as a string' => array(
+                'offset'   => '38427',
+                'expected' => 38427
+            ),
+
+            'Largest 32-bit integer' => array(
+                'offset'   => 2147483647,
+                'expected' => 2147483647
+            ),
+            'Largest 32-bit integer as a string' => array(
+                'offset'   => '2147483647',
+                'expected' => 2147483647
+            ),
+
+            'Largest 64-bit integer' => array(
+                'offset'   => 9223372036854775807,
+                'expected' => 9223372036854775807
+            ),
+            'Largest 64-bit integer as a string' => array(
+                'offset'   => '9223372036854775807',
+                'expected' => 9223372036854775807
+            ),
+
+            'Decimal value' => array(
+                'offset'   => 123.9,
+                'expected' => 123
+            ),
+            'Decimal value as a string' => array(
+                'offset'   => '123.9',
+                'expected' => 123
+            ),
+
+            'Non-numeric string' => array(
+                'offset'   => 'foo',
+                'expected' => 0
+            ),
+            'Injected SQL' => array(
+                'offset'   => '3;DROP TABLE abc',
+                'expected' => 3
+            ),
+        );
     }
 
     public function testCombineAndFilterBy()

--- a/tests/Propel/Tests/Runtime/Adapter/Pdo/MysqlAdapterTest.php
+++ b/tests/Propel/Tests/Runtime/Adapter/Pdo/MysqlAdapterTest.php
@@ -78,6 +78,194 @@ class MysqlAdapterTest extends TestCaseFixtures
 
         return $con;
     }
+
+    /**
+     * @dataProvider dataApplyLimit
+     */
+    public function testApplyLimit($offset, $limit, $expectedSql)
+    {
+        $sql = '';
+
+        $db = new MysqlAdapter();
+        $db->applyLimit($sql, $offset, $limit);
+
+        $this->assertEquals($expectedSql, $sql, 'Generated SQL does not match expected SQL');
+    }
+
+    public function dataApplyLimit()
+    {
+        return array(
+
+            /*
+                Offset & limit = 0
+             */
+
+            'Zero offset & limit' => array(
+                'offset'      => 0,
+                'limit'       => 0,
+                'expectedSql' => ' LIMIT 0'
+            ),
+
+            /*
+                Offset = 0
+             */
+
+            '32-bit limit' => array(
+                'offset'      => 0,
+                'limit'       => 4294967295,
+                'expectedSql' => ' LIMIT 4294967295'
+            ),
+            '32-bit limit as a string' => array(
+                'offset'      => 0,
+                'limit'       => '4294967295',
+                'expectedSql' => ' LIMIT 4294967295'
+            ),
+
+            '64-bit limit' => array(
+                'offset'      => 0,
+                'limit'       => 9223372036854775807,
+                'expectedSql' => ' LIMIT 9223372036854775807'
+            ),
+            '64-bit limit as a string' => array(
+                'offset'      => 0,
+                'limit'       => '9223372036854775807',
+                'expectedSql' => ' LIMIT 9223372036854775807'
+            ),
+
+            'Float limit' => array(
+                'offset'      => 0,
+                'limit'       => 123.9,
+                'expectedSql' => ' LIMIT 123'
+            ),
+            'Float limit as a string' => array(
+                'offset'      => 0,
+                'limit'       => '123.9',
+                'expectedSql' => ' LIMIT 123'
+            ),
+
+            'Negative limit' => array(
+                'offset'      => 0,
+                'limit'       => -1,
+                'expectedSql' => ''
+            ),
+            'Non-numeric string limit' => array(
+                'offset'      => 0,
+                'limit'       => 'foo',
+                'expectedSql' => ' LIMIT 0'
+            ),
+            'SQL injected limit' => array(
+                'offset'      => 0,
+                'limit'       => '3;DROP TABLE abc',
+                'expectedSql' => ' LIMIT 3'
+            ),
+
+            /*
+                Limit = 0
+             */
+
+            '32-bit offset' => array(
+                'offset'      => 4294967295,
+                'limit'       => 0,
+                'expectedSql' => ' LIMIT 4294967295, 0'
+            ),
+            '32-bit offset as a string' => array(
+                'offset'      => '4294967295',
+                'limit'       => 0,
+                'expectedSql' => ' LIMIT 4294967295, 0'
+            ),
+
+            '64-bit offset' => array(
+                'offset'      => 9223372036854775807,
+                'limit'       => 0,
+                'expectedSql' => ' LIMIT 9223372036854775807, 0'
+            ),
+            '64-bit offset as a string' => array(
+                'offset'      => '9223372036854775807',
+                'limit'       => 0,
+                'expectedSql' => ' LIMIT 9223372036854775807, 0'
+            ),
+
+            'Float offset' => array(
+                'offset'      => 123.9,
+                'limit'       => 0,
+                'expectedSql' => ' LIMIT 123, 0'
+            ),
+            'Float offset as a string' => array(
+                'offset'      => '123.9',
+                'limit'       => 0,
+                'expectedSql' => ' LIMIT 123, 0'
+            ),
+
+            'Negative offset' => array(
+                'offset'      => -1,
+                'limit'       => 0,
+                'expectedSql' => ' LIMIT 0'
+            ),
+            'Non-numeric string offset' => array(
+                'offset'      => 'foo',
+                'limit'       => 0,
+                'expectedSql' => ' LIMIT 0'
+            ),
+            'SQL injected offset' => array(
+                'offset'      => '3;DROP TABLE abc',
+                'limit'       => 0,
+                'expectedSql' => ' LIMIT 3, 0'
+            ),
+
+            /*
+                Offset & limit != 0
+             */
+
+            array(
+                'offset'      => 4294967295,
+                'limit'       => 999,
+                'expectedSql' => ' LIMIT 4294967295, 999'
+            ),
+            array(
+                'offset'      => '4294967295',
+                'limit'       => 999,
+                'expectedSql' => ' LIMIT 4294967295, 999'
+            ),
+
+            array(
+                'offset'      => 9223372036854775807,
+                'limit'       => 999,
+                'expectedSql' => ' LIMIT 9223372036854775807, 999'
+            ),
+            array(
+                'offset'      => '9223372036854775807',
+                'limit'       => 999,
+                'expectedSql' => ' LIMIT 9223372036854775807, 999'
+            ),
+
+            array(
+                'offset'      => 123.9,
+                'limit'       => 999,
+                'expectedSql' => ' LIMIT 123, 999'
+            ),
+            array(
+                'offset'      => '123.9',
+                'limit'       => 999,
+                'expectedSql' => ' LIMIT 123, 999'
+            ),
+
+            array(
+                'offset'      => -1,
+                'limit'       => 999,
+                'expectedSql' => ' LIMIT 999'
+            ),
+            array(
+                'offset'      => 'foo',
+                'limit'       => 999,
+                'expectedSql' => ' LIMIT 999'
+            ),
+            array(
+                'offset'      => '3;DROP TABLE abc',
+                'limit'       => 999,
+                'expectedSql' => ' LIMIT 3, 999'
+            ),
+        );
+    }
 }
 
 class TestableMysqlAdapter extends MysqlAdapter


### PR DESCRIPTION
These changes fix vulnerabilities in the MySQL adapter that allow SQL injection via query `limit()` methods:
```php
UserQuery::create()->limit('1;DROP TABLE users')->find();
```

Fixes were applied to both the MySQL adapter and the database-agnostic `Criteria` class to prevent other/future adapters from being susceptible to similar SQL injection vulnerabilities.

This pull request is a similar fix to the ones for Propel 1.x and 2.x

Fixes: https://github.com/propelorm/Propel3/issues/73
Related:
- https://github.com/propelorm/Propel/pull/1054
- https://github.com/propelorm/Propel2/pull/1465