### PR TITLE
Replaced tabs with spaces in generated code fixes #4

### DIFF
--- a/src/Propel/Generator/Builder/Om/AbstractBuilder.php
+++ b/src/Propel/Generator/Builder/Om/AbstractBuilder.php
@@ -10,9 +10,10 @@
 
 namespace Propel\Generator\Builder\Om;
 
-use gossi\codegen\generator\CodeGenerator;
 use gossi\codegen\model\PhpMethod;
 use Propel\Common\Types\BuildableFieldTypeInterface;
+use Propel\Generator\Code\CodeGenerator;
+use Propel\Generator\Code\ModelGenerator;
 use Propel\Generator\Builder\DataModelBuilder;
 use Propel\Generator\Builder\Om\Component\BuildComponent;
 use Propel\Generator\Builder\Om\Component\ComponentTrait;
@@ -109,6 +110,8 @@ abstract class AbstractBuilder extends DataModelBuilder
         $this->applyBehaviorModifier();
 
         $generator = new CodeGenerator();
+        $modelGenerator = new ModelGenerator($generator->getConfig());
+        $generator->setModelGenerator($modelGenerator);
 
         $code = "<?php\n\n" . $generator->generate($this->getDefinition());
 

--- a/src/Propel/Generator/Code/CodeGenerator.php
+++ b/src/Propel/Generator/Code/CodeGenerator.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types=1);
+/**
+ * This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT License
+ */
+
+namespace Propel\Generator\Code;
+
+use gossi\codegen\generator\CodeGenerator as GossiCodeGenerator;
+
+/**
+ * @author Gregor Panek <gp@gregorpanek.de>
+ */
+class CodeGenerator extends GossiCodeGenerator
+{
+    /**
+     * Set custom ModelGenerator
+     * @param Prope\Generator\Code\ModelGenerator $generator
+     */
+    public function setModelGenerator(ModelGenerator $generator): void
+    {
+        $this->generator = $generator;
+    }
+}

--- a/src/Propel/Generator/Code/ModelGenerator.php
+++ b/src/Propel/Generator/Code/ModelGenerator.php
@@ -1,0 +1,107 @@
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT License
+ */
+
+namespace Propel\Generator\Code;
+
+use gossi\codegen\generator\ModelGenerator as GossiModelGenerator;
+use gossi\codegen\generator\BuilderFactory;
+use gossi\codegen\config\CodeGeneratorConfig;
+use gossi\codegen\model\AbstractModel;
+use gossi\codegen\generator\utils\Writer;
+
+/**
+ * @author Gregor Panek <gp@gregorpanek.de>
+ */
+class ModelGenerator extends GossiModelGenerator
+{
+
+    /**
+     * @var CodeGeneratorConfig
+     */
+    protected $customConfig;
+
+    /**
+     * @var Writer
+     */
+    protected $customWriter;
+
+    /**
+     * @var BuilderFactory
+     */
+    protected $customFactory;
+
+    /**
+     * @param CodeGeneratorConfig|array $config
+     */
+    public function __construct($config = null)
+    {
+        if ($config === null) {
+            $this->customConfig = new CodeGeneratorConfig(['generateDocblock' => false]);
+        }
+
+        if ($config instanceof CodeGeneratorConfig) {
+            $this->customConfig = $config;
+        }
+
+        if (is_array($config)) {
+            $this->customConfig = new CodeGeneratorConfig($config);
+        }
+
+        $this->customWriter = new Writer(['indentation_character' => ' ', 'indentation_size' => 4]);
+        $this->customFactory = new BuilderFactory($this);
+    }
+
+    /**
+     * @return CodeGeneratorConfig
+     */
+    public function getConfig()
+    {
+        return $this->customConfig;
+    }
+    
+    /**
+     * @return Writer
+     */
+    public function getWriter()
+    {
+        return $this->customWriter;
+    }
+
+    /**
+     * Initalize Writer object with passed options
+     * @param array $options
+     */
+    public function setWriterOptions(array $options): void
+    {
+        $this->customWriter = new Writer($options);
+    }
+    
+    /**
+     * @return BuilderFactory
+     */
+    public function getFactory()
+    {
+        return $this->customFactory;
+    }
+
+    /**
+     * @param AbstractModel $model
+     * @return string
+     */
+    public function generate(AbstractModel $model)
+    {
+        $this->customWriter->reset();
+        
+        $builder = $this->customFactory->getBuilder($model);
+        $builder->build($model);
+
+        return $this->customWriter->getContent();
+    }
+}


### PR DESCRIPTION
This is my implementation to replace tabs with spaces in generated code. Solution is not the best because the library which I had to extends uses a lot of private class member variables. 

New default settings are 4 spaces for indentation. Configuration is possible through new method setWriterOptions in src/Propel/Generator/Code/ModelGenerator.php

If the place for the new classes does not fit your expectations then let me know.